### PR TITLE
Automate option processing

### DIFF
--- a/Follower SkyPatcher NPC Replacer Converter.pas
+++ b/Follower SkyPatcher NPC Replacer Converter.pas
@@ -239,7 +239,7 @@ begin
     if selected[1] = 'True' then
       removeFollowerNPC := true;
       
-    // 肌テクスチャを変更するか
+    // 肌を変更するか
     if selected[2] = 'True' then
       replaceSkin := true;
       
@@ -372,23 +372,23 @@ begin
     end;
   end;
 
-  // 肌、性別、種族、声のオプションに応じて、各行をコメントアウトさせる
+  // skinオプションの選択に応じて、設定行をコメントアウトする
   if replaceSkin = false then
     commentOutSkin := ';';
   
   // フォロワーNPCの性別、種族、音声タイプを取得
   followerFlags := ElementByPath(e, 'ACBS - Configuration');
   followerRaceElement := ElementByPath(e, 'RNAM');
-  followerRaceRecord := LinksTo(followerRaceElement);
+  followerRaceRecord := MasterOrSelf(LinksTo(followerRaceElement));
   followerVoiceTypeElement := ElementByPath(e, 'VTCK');
-  followerVoiceTypeRecord := LinksTo(followerVoiceTypeElement);
+  followerVoiceTypeRecord := MasterOrSelf(LinksTo(followerVoiceTypeElement));
   
   // ターゲットNPCの性別、種族、音声タイプを取得
   targetFlags := ElementByPath(targetRecord, 'ACBS - Configuration');
   targetRaceElement := ElementByPath(targetRecord, 'RNAM');
-  targetRaceRecord := LinksTo(targetRaceElement);
+  targetRaceRecord := MasterOrSelf(LinksTo(targetRaceElement));
   targetVoiceTypeElement := ElementByPath(targetRecord, 'VTCK');
-  targetVoiceTypeRecord := LinksTo(targetVoiceTypeElement);
+  targetVoiceTypeRecord := MasterOrSelf(LinksTo(targetVoiceTypeElement));
   
   // フォロワーNPCとターゲットNPCの性別、種族、音声タイプを比較して、結果をフラグに反映する。
   if GetElementEditValues(targetFlags, 'Flags\Female') = GetElementEditValues(followerFlags, 'Flags\Female') then


### PR DESCRIPTION
オプションの挙動を自動化。
ターゲットとフォロワーのレコードを比較して、性別、種族、音声タイプが異なる場合に設定行を自動的に追記するようにした。
この変更により、ユーザによるオプション選択は不要となったのでチェックリストから削除した。

スキンオプションの追加と設定変更
今まではcopyVisualStyleとskinを1行で書いていたが、skinをより柔軟に操作したくなったので別の行に分けた。
基本的にセットで使用するオペレーションなので、チェックリストはデフォルトでオンに、チェックを外してもコメントアウトするだけで、行自体は出力する。
フォロワーのWNAMが未設定だった場合はskinにnullを設定し、デフォルトのボディタイプを参照するようにした。
こういう場合、今まではフォロワーNPCのレコードIDを設定していたが、これは無効な設定だったようだ。